### PR TITLE
Fix forced exit on macOS

### DIFF
--- a/src/bin/v1541commander/main.cpp
+++ b/src/bin/v1541commander/main.cpp
@@ -34,6 +34,7 @@ void handlesig(int sig)
 int main(int argc, char **argv)
 {
 #ifndef _WIN32
+#ifndef __APPLE__
 #ifndef DEBUG
     pid_t pid = fork();
     if (pid < 0) return 1;
@@ -51,6 +52,7 @@ int main(int argc, char **argv)
 	}
     }
     setsid();
+#endif
 #endif
 #endif
 
@@ -117,11 +119,13 @@ int main(int argc, char **argv)
     if (commander.isPrimaryInstance())
     {
 #ifndef _WIN32
+#ifndef __APPLE__
 #ifndef DEBUG
         freopen("/dev/null", "r", stdin);
         freopen("/dev/null", "w", stdout);
         freopen("/dev/null", "w", stderr);
 	kill(getppid(), SIGHUP);
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
macOS enforces binaries to only async-signal safe operations after fork() but without exec(). When v1541commander is compiled with default optimisations, this becomes a problem since macOS cannot reliably determine, if any unsafe operations are used. Disabling use of fork() works around this.